### PR TITLE
Fix mute endpoints so they accept "true" / "false" as specified in endpoint document

### DIFF
--- a/PJLink.postman_collection.json
+++ b/PJLink.postman_collection.json
@@ -236,7 +236,7 @@
 				"header": [],
 				"body": {
 					"mode": "raw",
-					"raw": "\"on\"",
+					"raw": "\"true\"",
 					"options": {
 						"raw": {
 							"language": "json"
@@ -264,7 +264,7 @@
 				"header": [],
 				"body": {
 					"mode": "raw",
-					"raw": "\"on\"",
+					"raw": "\"true\"",
 					"options": {
 						"raw": {
 							"language": "json"
@@ -293,7 +293,7 @@
 				"header": [],
 				"body": {
 					"mode": "raw",
-					"raw": "\"on\"",
+					"raw": "\"true\"",
 					"options": {
 						"raw": {
 							"language": "json"

--- a/pjlink_curl_tests.sh
+++ b/pjlink_curl_tests.sh
@@ -46,17 +46,17 @@ sleep 1
 
 curl -X PUT "http://$MICROSERVICE_URL/$DEVICE_FQDN/videomute" \
      -H "Content-Type: application/json" \
-     -d '"on"'
+     -d '"true"'
 sleep 1
 
 curl -X PUT "http://$MICROSERVICE_URL/$DEVICE_FQDN/audiomute/1" \
      -H "Content-Type: application/json" \
-     -d '"on"'
+     -d '"true"'
 sleep 1
 
 curl -X PUT "http://$MICROSERVICE_URL/$DEVICE_FQDN/audioandvideomute/1" \
      -H "Content-Type: application/json" \
-     -d '"on"'
+     -d '"true"'
 sleep 1
 
 echo "Tests complete."

--- a/source/driver.go
+++ b/source/driver.go
@@ -224,9 +224,10 @@ func setMuteDo(socketKey string, state string, which string) (string, error) {
 	PJLinkEstablishConnectionIfNeeded(socketKey)
 
 	if which == "video" {
-		if state == `"on"` {
+		// Allows backwards compatibility for "on" or "off"
+		if state == `"on"` || state == `"true"` {
 			state = "11"
-		} else if state == `"off"` {
+		} else if state == `"off"` || state == `"false"` {
 			state = "10"
 		} else {
 			errMsg := fmt.Sprintf(function + " - svfdsq43 unrecognized state value: " + state)
@@ -234,9 +235,9 @@ func setMuteDo(socketKey string, state string, which string) (string, error) {
 			return state, errors.New(errMsg)
 		}
 	} else if which == "audio" {
-		if state == `"on"` {
+		if state == `"on"` || state == `"true"` {
 			state = "21"
-		} else if state == `"off"` {
+		} else if state == `"off"` || state == `"false"` {
 			state = "20"
 		} else {
 			errMsg := fmt.Sprintf(function + " - 345wg unrecognized state value: " + state)
@@ -244,10 +245,14 @@ func setMuteDo(socketKey string, state string, which string) (string, error) {
 			return state, errors.New(errMsg)
 		}
 	} else if which == "both" {
-		if state == `"on"` {
+		if state == `"on"` || state == `"true"` {
 			state = "31"
-		} else if state == `"off"` {
+		} else if state == `"off"` || state == `"false"` {
 			state = "30"
+		} else {
+			errMsg := fmt.Sprintf(function + " - 89dsi unrecognized state value: " + state)
+			framework.AddToErrors(socketKey, errMsg)
+			return state, errors.New(errMsg)
 		}
 	}
 


### PR DESCRIPTION
Closes #2 

- Add "true" and "false" as accepted mute state values
- Keep backwards compatibility with existing "on" and "off"
- Log error on else path for audioandvidomute if value is not recognized (parity with videomute and audiomute)
- Update Postman manifest to use "true" and "false" for mutes
- Update curl test to use "true" and "false" for mutes